### PR TITLE
Add distance filter

### DIFF
--- a/motion_blur/moblur_shader.shader
+++ b/motion_blur/moblur_shader.shader
@@ -5,7 +5,7 @@ uniform vec3 linear_velocity;
 uniform vec3 angular_velocity; //rads
 uniform int iteration_count : hint_range(2, 50);
 uniform float intensity : hint_range(0, 1);
-
+uniform float startRadius;
 
 void fragment()
 { 
@@ -33,11 +33,15 @@ void fragment()
 	
 	vec3 col = vec3(0.0);
 	float counter = 0.0;
-	for (int i = 0; i < iteration_count; i++)
-	{
-		vec2 offset = pixel_diff_ndc * (float(i) / float(iteration_count) - 0.5) * intensity; 
-		col += textureLod(SCREEN_TEXTURE, SCREEN_UV + offset,0.0).rgb;
-		counter++;
+	if(length(r) >= startRadius){
+		for (int i = 0; i < iteration_count; i++)
+		{
+			vec2 offset = pixel_diff_ndc * (float(i) / float(iteration_count) - 0.5) * intensity; 
+			col += textureLod(SCREEN_TEXTURE, SCREEN_UV + offset,0.0).rgb;
+			counter++;
+		}
+		ALBEDO = col / counter;
 	}
-	ALBEDO = col / counter;
+	else
+		ALBEDO = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0).rgb;
 }


### PR DESCRIPTION
This resource is awesome and works well with Godot up to v3.2.1.

However, there's one issue I've found.  The blur effect doesn't look right when used on pixels really close to the camera.  I noticed this when using the effect for a first person game camera where the body and legs can be seen when looking at the ground.  In this scenario, when the player is moving and looking down, the blur effect on the attached body looks bad. 

This update adds a condition to the shader code that acts as a filter to prevent the blur effect from being applied to pixels that are too close to the camera, such as for the body and legs in a first person game camera.  The distance is set by way of the "startRadius" uniform.  I've found setting this value to 1 fixes the issue I was experiencing.  